### PR TITLE
Fix storage bug

### DIFF
--- a/data/ingredients.txt
+++ b/data/ingredients.txt
@@ -1,0 +1,2 @@
+bread | 2 | KILOGRAM
+egg | 1 | PIECE

--- a/data/recipes.txt
+++ b/data/recipes.txt
@@ -1,1 +1,1 @@
-bread || step1 | NIGHT_BEFORE | 50 || bread | 5 | KILOGRAM
+soup || EMPTY || EMPTY

--- a/src/main/java/essenmakanan/EssenMakanan.java
+++ b/src/main/java/essenmakanan/EssenMakanan.java
@@ -32,7 +32,7 @@ public class EssenMakanan {
         Ui.start();
 
         Scanner in = new Scanner(System.in);
-        String input = "";
+        String input;
 
         Command command = null;
         Ui.showCommands();
@@ -41,21 +41,18 @@ public class EssenMakanan {
             try {
                 command = parser.parseCommand(input, recipes, ingredients);
                 command.executeCommand();
+                ingredientStorage.saveData(ingredients.getIngredients());
+                recipeStorage.saveData(recipes.getRecipes());
             } catch (EssenCommandException exception) {
                 exception.handleException();
             } catch (EssenFormatException exception) {
                 exception.handleException();
             } catch (EssenOutOfRangeException exception) {
                 exception.handleException();
+            } catch (IOException exception) {
+                Ui.handleIOException(exception);
             }
         } while (!ExitCommand.isExitCommand(command));
-
-        try {
-            ingredientStorage.saveData(ingredients.getIngredients());
-            recipeStorage.saveData(recipes.getRecipes());
-        } catch (IOException exception) {
-            Ui.handleIOException(exception);
-        }
     }
 
     public void setup() {
@@ -68,12 +65,14 @@ public class EssenMakanan {
             ingredients = new IngredientList(ingredientStorage.restoreSavedData());
         } catch (EssenFileNotFoundException exception) {
             exception.handleFileNotFoundException(DATA_DIRECTORY, DATA_INGREDIENT_PATH);
+            ingredients = new IngredientList();
         }
 
         try {
             recipes = new RecipeList(recipeStorage.restoreSavedData());
         } catch (EssenFileNotFoundException exception) {
             exception.handleFileNotFoundException(DATA_DIRECTORY, DATA_RECIPE_PATH);
+            recipes = new RecipeList();
         }
     }
 

--- a/src/test/java/essenmakanan/command/DuplicateRecipeCommandTest.java
+++ b/src/test/java/essenmakanan/command/DuplicateRecipeCommandTest.java
@@ -60,7 +60,7 @@ public class DuplicateRecipeCommandTest {
 
         assertEquals(recipe.getTitle() + " (copy)", duplicatedRecipe.getTitle());
 
-        assertEquals(recipe.getRecipeStepByIndex(0).getDescription( )
+        assertEquals(recipe.getRecipeStepByIndex(0).getDescription()
                 , duplicatedRecipe.getRecipeStepByIndex(0).getDescription());
         assertEquals(recipe.getRecipeStepByIndex(1).getDescription()
                 , duplicatedRecipe.getRecipeStepByIndex(1).getDescription());


### PR DESCRIPTION
Fix a bug where the storage will not save any data when exiting the application with `ctrl + c` and `NullPointerException` when creating a recipe / ingredient in first time session (when data folder and storage text files are created).

Fixes #169 